### PR TITLE
Fix deprecated API usage and GNOME Shell 49 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+### GNOMEShellExtension GitIgnore
+# Ignored files for GNOME extension git repository
+
+*.zip

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,5 @@
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';
-import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -50,7 +49,7 @@ export default class JustShowsMemoryExtension extends Extension {
             reactive: false
         });
 
-        this._indicator.actor.add_child(this._label);
+        this._indicator.add_child(this._label);
     }
 
     disable() {

--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,11 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "49"
   ],
   "url": "https://github.com/troizet/just-shows-memory-usage",
   "uuid": "just_shows_memory_usage@troizet.github.com",
   "settings-schema": "org.gnome.shell.extensions.just-shows-memory-usage",
-  "version": 3
+  "version": 6
 }


### PR DESCRIPTION
Hi! Thanks for this extension, I use it daily and it's super useful.

Recently, Gnome 49 got released, and it no longer works, so here's a fix. 

1. **Fixed deprecated `actor` property usage** - Replaced `this._indicator.actor.add_child()` with `this._indicator.add_child()`. The `actor` property was deprecated in GNOME Shell 42+ and causes warnings/errors in newer versions.

2. **Removed unused Gio import** - Cleaned up an unused import that was cluttering the code.

3. **Added GNOME Shell 49 support** - Updated metadata.json to include shell version 49.

4. **Added .gitignore** - Excludes built `.zip` files from version control.


Tested on GNOME Shell 49 - extension loads without errors and displays memory usage correctly.

Feel free to tweak it if you want! 